### PR TITLE
Support for stm32f1 medium density devices

### DIFF
--- a/MIT-LICENSE
+++ b/MIT-LICENSE
@@ -1,4 +1,5 @@
 Copyright (c) 2010 Bogdan Marinescu
+Copyright (c) 2015 Simo Bergman
  
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+
+# Copyright (c) 2015 Simo Bergman
+
+CC=gcc
+EXE=stm32ld
+OBJ=main.o serial_posix.o stm32ld.o
+CFLAGS= -Wall
+
+all: $(EXE)
+
+$(EXE):$(OBJ)
+
+clean: 
+	rm -f $(OBJ) $(EXE)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ If lake is installed:
 Otherwise:
 
 Linux/Mac OS X:
-> gcc -o stm32ld main.c stm32ld.c serial_posix.c
+> make
 
 
 Original source author: Bogdan Marinescu <bogdan.marinescu@gmail.com>

--- a/main.c
+++ b/main.c
@@ -132,18 +132,16 @@ int main( int argc, const char **argv )
   }
   else
   {
-    uint16_t chip_id = 0;
     const uint16_t *chip_ids = SUPPORTED_CHIP_IDS;
     printf( "Chip ID: %04X\n", version );
     while( *chip_ids != 0 )
     {
       if( *chip_ids == version )
       {
-        chip_id = version;
         break;
       }
     }
-    if( chip_id == 0 )
+    if( *chip_ids == 0 )
     {
       fprintf( stderr, "Unsupported chip ID\n" );
       exit( 1 );

--- a/main.c
+++ b/main.c
@@ -15,8 +15,15 @@ static u32 fpsize;
 #define BL_MKVER( major, minor )    ( ( major ) * 256 + ( minor ) ) 
 #define BL_MINVERSION               BL_MKVER( BL_VERSION_MAJOR, BL_VERSION_MINOR )
 
-#define CHIP_ID           0x0414
-#define CHIP_ID_ALT           0x0413
+
+// Supported CHIP_IDs
+static const uint16_t SUPPORTED_CHIP_IDS[] =
+{
+  0x0410,
+  0x0414,
+  0x0413,
+  0
+};
 
 // ****************************************************************************
 // Helper functions and macros
@@ -125,8 +132,18 @@ int main( int argc, const char **argv )
   }
   else
   {
+    uint16_t chip_id = 0;
+    const uint16_t *chip_ids = SUPPORTED_CHIP_IDS;
     printf( "Chip ID: %04X\n", version );
-    if( version != CHIP_ID && version != CHIP_ID_ALT )
+    while( *chip_ids != 0 )
+    {
+      if( *chip_ids == version )
+      {
+        chip_id = version;
+        break;
+      }
+    }
+    if( chip_id == 0 )
     {
       fprintf( stderr, "Unsupported chip ID\n" );
       exit( 1 );

--- a/main.c
+++ b/main.c
@@ -112,7 +112,7 @@ int main( int argc, const char **argv )
     printf( "Found bootloader version: %d.%d\n", major, minor );
     if( BL_MKVER( major, minor ) < BL_MINVERSION )
     {
-      fprintf( stderr, "Unsupported bootloader version" );
+      fprintf( stderr, "Unsupported bootloader version\n" );
       exit( 1 );
     }
   }
@@ -128,7 +128,7 @@ int main( int argc, const char **argv )
     printf( "Chip ID: %04X\n", version );
     if( version != CHIP_ID && version != CHIP_ID_ALT )
     {
-      fprintf( stderr, "Unsupported chip ID" );
+      fprintf( stderr, "Unsupported chip ID\n" );
       exit( 1 );
     }
   }

--- a/stm32ld.c
+++ b/stm32ld.c
@@ -1,6 +1,7 @@
 // STM32 bootloader client
 
 #include <stdio.h>
+#include <unistd.h>
 #include "serial.h"
 #include "type.h"
 #include "stm32ld.h"
@@ -102,7 +103,6 @@ int stm32_get_version( u8 *major, u8 *minor )
 {
   u8 i, version;
   int temp, total;
-  int tries = STM32_RETRY_COUNT;  
 
   STM32_CHECK_INIT;
   stm32h_send_command( STM32_CMD_GET_COMMAND );
@@ -123,7 +123,6 @@ int stm32_get_version( u8 *major, u8 *minor )
 // Get chip ID
 int stm32_get_chip_id( u16 *version )
 {
-  u8 temp;
   int vh, vl;
 
   STM32_CHECK_INIT;

--- a/stm32ld.h
+++ b/stm32ld.h
@@ -47,6 +47,8 @@ int stm32_write_unprotect();
 int stm32_erase_flash();
 int stm32_write_flash( p_read_data read_data_func, p_progress progress_func );
 int stm32_go_command( void );
+int stm32_get_version( u8 *major, u8 *minor );
+int stm32_extended_erase_flash();
 
 #endif
 


### PR DESCRIPTION
- Added support for stm32f1 medium density device.
- Added basic makefile to easy up Mac OS X and Linux builds
- Fixed few compiler warnings
- Updated copyright info according to the made changes.
