### PR TITLE
Fixed chipID testing.

### DIFF
--- a/main.c
+++ b/main.c
@@ -140,6 +140,7 @@ int main( int argc, const char **argv )
       {
         break;
       }
+      chip_ids++;
     }
     if( *chip_ids == 0 )
     {


### PR DESCRIPTION
Fixes an issue with the chipID detection:
- Loop condition variable was not updated, while the while loop was iterated. This caused an infinite loop, if you are not using the first chip in the SUPPORTED_CHIP_IDS array.
